### PR TITLE
Create a new TaskMonitor each time to avoid flaky tests.

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
@@ -127,7 +127,7 @@ public class TestTaskMonitor {
   @Test
   public void testDoNotPurgeRPCTask() throws Exception {
     int RPCTaskNums = 10;
-    TaskMonitor tm = TaskMonitor.get();
+    TaskMonitor tm = new TaskMonitor(new Configuration());
     for(int i = 0; i < RPCTaskNums; i++) {
       tm.createRPCStatus("PRCTask" + i);
     }


### PR DESCRIPTION
## What is the purpose of this PR
- This PR cleans the state polluted by `org.apache.hadoop.hbase.monitoring.TestTaskMonitor.testDoNotPurgeRPCTask`.

- It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
## Reproduce the test failure
- Run the test twice in the same JVM. 
## Expected  result:
- The tests should run successfully when multiple tests that use this state are run in the same JVM.
## Actual result:
- We get the failure:
`[ERROR] Failures: 
[ERROR] testDoNotPurgeRPCTask:144 RPC Tasks have been purged! expected:<10> but was:<20>`
## Why the test fails
- Each time this test runs,10 RPCtasks are created and added to the ArrayList `rpcTasks`, but `rpcTasks` is not completely purged when the test ends. So next time the test starts, the remaining RPC tasks lead to an assertion failure.
## Fix
Create a new `TaskMonitor` each time to avoid pollution similar to the other tests (e.g., `testTaskMonitorBasics`, `testTasksGetAbortedOnLeak`) in `TestTaskMonitor`.