### PR TITLE
Clean shared state pollution to avoid flaky tests.

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
@@ -114,7 +114,12 @@ public class TestDrainReplicationQueuesForStandBy extends SyncReplicationTestBas
     for (int i = 0; i < 100; i++) {
       assertTrue(region2.get(new Get(Bytes.toBytes(i))).isEmpty());
     }
-    UTIL2.getAdmin().transitReplicationPeerSyncReplicationState(PEER_ID,
+    
+  @After 
+  public void tearDown() throws Exception {
+     UTIL2.getAdmin().transitReplicationPeerSyncReplicationState(PEER_ID,
       SyncReplicationState.DOWNGRADE_ACTIVE);
+    }
+    
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
@@ -114,6 +114,7 @@ public class TestDrainReplicationQueuesForStandBy extends SyncReplicationTestBas
     for (int i = 0; i < 100; i++) {
       assertTrue(region2.get(new Get(Bytes.toBytes(i))).isEmpty());
     }
+  }
 
   @After
   public void tearDown() throws Exception {
@@ -121,5 +122,4 @@ public class TestDrainReplicationQueuesForStandBy extends SyncReplicationTestBas
       SyncReplicationState.DOWNGRADE_ACTIVE);
     }
 
-  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
@@ -114,5 +114,7 @@ public class TestDrainReplicationQueuesForStandBy extends SyncReplicationTestBas
     for (int i = 0; i < 100; i++) {
       assertTrue(region2.get(new Get(Bytes.toBytes(i))).isEmpty());
     }
+    UTIL2.getAdmin().transitReplicationPeerSyncReplicationState(PEER_ID,
+      SyncReplicationState.DOWNGRADE_ACTIVE);
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.ReplicationTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
+import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -117,7 +118,7 @@ public class TestDrainReplicationQueuesForStandBy extends SyncReplicationTestBas
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void clean() throws Exception {
      UTIL2.getAdmin().transitReplicationPeerSyncReplicationState(PEER_ID,
       SyncReplicationState.DOWNGRADE_ACTIVE);
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
@@ -114,12 +114,12 @@ public class TestDrainReplicationQueuesForStandBy extends SyncReplicationTestBas
     for (int i = 0; i < 100; i++) {
       assertTrue(region2.get(new Get(Bytes.toBytes(i))).isEmpty());
     }
-    
-  @After 
+
+  @After
   public void tearDown() throws Exception {
      UTIL2.getAdmin().transitReplicationPeerSyncReplicationState(PEER_ID,
       SyncReplicationState.DOWNGRADE_ACTIVE);
     }
-    
+
   }
 }


### PR DESCRIPTION
## What is the purpose of this PR
- This PR fixes a flaky test to avoid shared state pollution  `org.apache.hadoop.hbase.replication.regionserver.TestDrainReplicationQueuesForStandBy.test`
## Reproduce the test failure
- Run the test twice in the same JVM.
## Expected result:
- The test should run successfully when multiple tests that use this state are run in the same JVM.
## Actual result:
- We get the failure:
```
org.apache.hadoop.hbase.DoNotRetryIOException: Can not transit current cluster state from STANDBY to STANDBY for peer id=1
```
## Why the test fails
- When the test ends, current cluster for peer id=1 is STANDBY, it can not be transitted from STANDBY to STANDBY. 
## Fix
- Reset the state when test ends.