### PR TITLE
Clean shared state pollution to avoid flaky tests.

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsHeapMemoryManagerSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsHeapMemoryManagerSource.java
@@ -94,6 +94,16 @@ public interface MetricsHeapMemoryManagerSource extends BaseSource {
    */
   void increaseAboveHeapOccupancyLowWatermarkCounter();
 
+ /**
+   * Clear the counter for heap occupancy percent above low watermark
+   */
+  void clearAboveHeapOccupancyLowWatermarkCounter();
+
+  /**
+   * Clear the counter for tuner.
+   */
+  void clearTunerDoNothingCounter();
+
   // Histograms
   String BLOCKED_FLUSH_NAME = "blockedFlushes";
   String BLOCKED_FLUSH_DESC = "Histogram for the number of blocked flushes in the memstore";

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsHeapMemoryManagerSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsHeapMemoryManagerSourceImpl.java
@@ -140,4 +140,14 @@ public class MetricsHeapMemoryManagerSourceImpl extends BaseSourceImpl implement
   public void increaseAboveHeapOccupancyLowWatermarkCounter() {
     aboveHeapOccupancyLowWatermarkCounter.incr();
   }
+
+  @Override
+  public void clearAboveHeapOccupancyLowWatermarkCounter() {
+    aboveHeapOccupancyLowWatermarkCounter.clear();
+  }
+
+  @Override
+  public void clearTunerDoNothingCounter() {
+    doNothingCounter.clear();
+  }
 }

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsHeapMemoryManagerSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsHeapMemoryManagerSourceImpl.java
@@ -44,8 +44,8 @@ public class MetricsHeapMemoryManagerSourceImpl extends BaseSourceImpl implement
   private final MutableGaugeLong memStoreSizeGauge;
   private final MutableGaugeLong blockCacheSizeGauge;
 
-  private final MutableFastCounter doNothingCounter;
-  private final MutableFastCounter aboveHeapOccupancyLowWatermarkCounter;
+  private MutableFastCounter doNothingCounter;
+  private MutableFastCounter aboveHeapOccupancyLowWatermarkCounter;
 
   public MetricsHeapMemoryManagerSourceImpl() {
     this(METRICS_NAME, METRICS_DESCRIPTION, METRICS_CONTEXT, METRICS_JMX_CONTEXT);

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/MutableFastCounter.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/MutableFastCounter.java
@@ -61,4 +61,9 @@ public class MutableFastCounter extends MutableCounter {
   public long value() {
     return counter.sum();
   }
+
+  public void clear() {
+    counter.reset();
+    setChanged();
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsHeapMemoryManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsHeapMemoryManager.java
@@ -105,4 +105,12 @@ public class MetricsHeapMemoryManager {
   public void increaseAboveHeapOccupancyLowWatermarkCounter() {
     source.increaseAboveHeapOccupancyLowWatermarkCounter();
   }
+
+  public void clearAboveHeapOccupancyLowWatermarkCounter() {
+    source.clearAboveHeapOccupancyLowWatermarkCounter();
+  }
+
+  public void clearTunerDoNothingCounter() {
+    source.clearTunerDoNothingCounter();
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsHeapMemoryManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsHeapMemoryManager.java
@@ -67,6 +67,9 @@ public class TestMetricsHeapMemoryManager {
 
     HELPER.assertCounter("aboveHeapOccupancyLowWaterMarkCounter", 10L, source);
     HELPER.assertCounter("tunerDoNothingCounter", 11L, source);
+
+    source.clearAboveHeapOccupancyLowWatermarkCounter();
+    source.clearTunerDoNothingCounter();
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of this PR
This PR fixes a flaky test to avoid shared state pollution `org.apache.hadoop.hbase.regionserver.TestMetricsHeapMemoryManager.testCounter`
## Reproduce the test failure
Run the test twice in the same JVM.
## Expected result:
The test should run successfully when multiple tests that use this state are run in the same JVM.
## Actual result:
We get the failure:
```
aboveHeapOccupancyLowWaterMarkCounter should be <10>, but was <20>
```
## Why the test fails
`aboveHeapOccupancyLowWatermarkCounter` and `doNothingCounter` were not clean when the test ends.
## Fix
Reset the state when the test ends.