### PR TITLE
Fix flaky tests

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServerSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServerSource.java
@@ -102,6 +102,7 @@ public interface MetricsHBaseServerSource extends ExceptionTrackingSource {
 
   String NETTY_DM_USAGE_DESC = "Current Netty direct memory usage.";
 
+  void teardown();
 
   void authorizationSuccess();
 

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServerSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServerSourceImpl.java
@@ -31,13 +31,13 @@ import org.apache.yetus.audience.InterfaceAudience;
 public class MetricsHBaseServerSourceImpl extends ExceptionTrackingSourceImpl
     implements MetricsHBaseServerSource {
   private final MetricsHBaseServerWrapper wrapper;
-  private final MutableFastCounter authorizationSuccesses;
-  private final MutableFastCounter authorizationFailures;
-  private final MutableFastCounter authenticationSuccesses;
-  private final MutableFastCounter authenticationFailures;
-  private final MutableFastCounter authenticationFallbacks;
-  private final MutableFastCounter sentBytes;
-  private final MutableFastCounter receivedBytes;
+  private MutableFastCounter authorizationSuccesses;
+  private MutableFastCounter authorizationFailures;
+  private MutableFastCounter authenticationSuccesses;
+  private MutableFastCounter authenticationFailures;
+  private MutableFastCounter authenticationFallbacks;
+  private MutableFastCounter sentBytes;
+  private MutableFastCounter receivedBytes;
 
 
   private MetricHistogram queueCallTime;
@@ -78,6 +78,17 @@ public class MetricsHBaseServerSourceImpl extends ExceptionTrackingSourceImpl
         REQUEST_SIZE_DESC);
     this.responseSize = this.getMetricsRegistry().newSizeHistogram(RESPONSE_SIZE_NAME,
               RESPONSE_SIZE_DESC);
+  }
+
+  @Override
+  public void teardown() {
+    authorizationSuccesses.clear();
+    authorizationFailures.clear();
+    authenticationSuccesses.clear();
+    authenticationFailures.clear();
+    authenticationFallbacks.clear();
+    sentBytes.clear();
+    receivedBytes.clear();
   }
 
   @Override

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSource.java
@@ -46,6 +46,7 @@ public interface ExceptionTrackingSource extends BaseSource {
 
   void exception();
 
+  void cleanexception()
   /**
    * Different types of exceptions
    */

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSourceImpl.java
@@ -75,6 +75,11 @@ public class ExceptionTrackingSourceImpl extends BaseSourceImpl
   }
 
   @Override
+  public void cleanexception() {
+    exceptions.clear();
+  }
+
+  @Override
   public void exception() {
     exceptions.incr();
   }

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/MutableFastCounter.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/MutableFastCounter.java
@@ -61,4 +61,9 @@ public class MutableFastCounter extends MutableCounter {
   public long value() {
     return counter.sum();
   }
+
+  public void clear() {
+    counter.reset();
+    setChanged();
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServer.java
@@ -48,6 +48,10 @@ public class MetricsHBaseServer {
                                           .create(serverName, wrapper);
   }
 
+  void teardown() {
+    source.teardown();
+  }
+
   void authorizationSuccess() {
     source.authorizationSuccess();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServer.java
@@ -48,6 +48,10 @@ public class MetricsHBaseServer {
                                           .create(serverName, wrapper);
   }
 
+  void cleanexception() {
+    source.cleanexception();
+  }
+
   void teardown() {
     source.teardown();
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcMetrics.java
@@ -148,6 +148,7 @@ public class TestRpcMetrics {
     HELPER.assertCounter("exceptions.OutOfOrderScannerNextException", 1, serverSource);
     HELPER.assertCounter("exceptions.NotServingRegionException", 1, serverSource);
     HELPER.assertCounter("exceptions", 5, serverSource);
+    serverSource.teardown();
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsTableAggregate.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsTableAggregate.java
@@ -33,6 +33,8 @@ import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -40,6 +42,9 @@ import org.slf4j.LoggerFactory;
 
 @Category({ RegionServerTests.class, MediumTests.class })
 public class TestMetricsTableAggregate {
+
+  @Rule
+  public TestName name = new TestName();
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
@@ -50,8 +55,8 @@ public class TestMetricsTableAggregate {
   private static MetricsAssertHelper HELPER =
     CompatibilityFactory.getInstance(MetricsAssertHelper.class);
 
-  private String tableName = "testTableMetrics";
-  private String pre = "Namespace_default_table_" + tableName + "_metric_";
+  private String tableName;
+  private String pre;
 
   private MetricsTableWrapperStub tableWrapper;
   private MetricsTable mt;
@@ -66,6 +71,8 @@ public class TestMetricsTableAggregate {
 
   @Before
   public void setUp() {
+    tableName =name.getMethodName();
+    pre = "Namespace_default_table_" + tableName + "_metric_";
     tableWrapper = new MetricsTableWrapperStub(tableName);
     mt = new MetricsTable(tableWrapper);
     rsWrapper = new MetricsRegionServerWrapperStub();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsTableAggregate.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsTableAggregate.java
@@ -71,7 +71,7 @@ public class TestMetricsTableAggregate {
 
   @Before
   public void setUp() {
-    tableName =name.getMethodName();
+    tableName = name.getMethodName();
     pre = "Namespace_default_table_" + tableName + "_metric_";
     tableWrapper = new MetricsTableWrapperStub(tableName);
     mt = new MetricsTable(tableWrapper);
@@ -83,6 +83,8 @@ public class TestMetricsTableAggregate {
 
   @Test
   public void testRequestMetrics() throws IOException {
+    rsm.updateFlush(tableName, 1, 2, 3);
+    rsm.updateFlush(tableName, 1, 2, 3);
     HELPER.assertCounter(pre + "readRequestCount", 10, agg);
     HELPER.assertCounter(pre + "writeRequestCount", 20, agg);
     HELPER.assertCounter(pre + "totalRequestCount", 30, agg);
@@ -90,6 +92,8 @@ public class TestMetricsTableAggregate {
 
   @Test
   public void testRegionAndStoreMetrics() throws IOException {
+    rsm.updateFlush(tableName, 1, 2, 3);
+    rsm.updateFlush(tableName, 1, 2, 3);
     HELPER.assertGauge(pre + "memstoreSize", 1000, agg);
     HELPER.assertGauge(pre + "storeFileSize", 2000, agg);
     HELPER.assertGauge(pre + "tableSize", 3000, agg);


### PR DESCRIPTION
# What is the purpose of this PR
This PR fixes 3 flaky tests to avoid shared state pollution
```
org.apache.hadoop.hbase.regionserver.TestMetricsTableAggregate.testCompaction
org.apache.hadoop.hbase.regionserver.TestMetricsTableAggregate.testFlush
org.apache.hadoop.hbase.ipc.TestRpcMetrics.testSourceMethods
```

# Reproduce the test failure
Run the tests twice in the same JVM.

# Expected result:
The tests should run successfully when multiple tests that use the same state are run in the same JVM.

# Why the tests fail
Test `org.apache.hadoop.hbase.ipc.TestRpcMetrics.testSourceMethods`:
The same server "HMaster" was used to do all the operations.

Tests: `org.apache.hadoop.hbase.regionserver.TestMetricsTableAggregate.testCompaction` and
`org.apache.hadoop.hbase.regionserver.TestMetricsTableAggregate.testFlush`

For these 2 tests, it seems that a new `MetricsRegionServer` is created each time, and `agg` should be a new one from the newly created MetricsRegionServer. But because of the same `tableName`, so `agg` is the same one in different runs. 


# Fix
2 kinds of fixes for these similar tests, 
one is manually cleaning as `org.apache.hadoop.hbase.ipc.TestRpcMetrics.testSourceMethods`, also similar to https://github.com/LALAYANG/hbase/pull/4; 
the other is to try to create new objects each time as the other 2 tests.
